### PR TITLE
Update elvis-operator.java

### DIFF
--- a/code/java/basic/elvis-operator.java
+++ b/code/java/basic/elvis-operator.java
@@ -1,3 +1,5 @@
-val result = Optional.ofNullable(nullableVariable)
-    .flatMap(v -> Optinal.ofNullable(v.someNullableMethodCall()))
-    .orElseGet(() -> fallbackIfNullMethodCall())
+boolean result = nullableVariable == null
+
+if (!result) {
+    result = nullableVariable.someNullableMethodCall() || fallbackIfNullMethodCall()
+} 


### PR DESCRIPTION
It's even shorter if we maintain the return rather than the assignment, but I think this is easier to read than the current example.

Also, there is no such thing as val in Java.