### PR TITLE
Fix differing behaviour in IO example

### DIFF
--- a/code/java/io/read-file-to-string.java
+++ b/code/java/io/read-file-to-string.java
@@ -4,3 +4,4 @@ try {
 } catch (IOException e) {
     e.printStackTrace();
 }
+System.out.println(content);

--- a/code/kotlin/io/read-file-to-string.kt
+++ b/code/kotlin/io/read-file-to-string.kt
@@ -1,1 +1,8 @@
-File("doc.txt").readText()
+var content: String?
+try {
+    content = File("doc.txt").readText()
+} catch (e: IOException) {
+    e.printStackTrace()
+    content = null
+}
+println(content)


### PR DESCRIPTION
 - Added a use for the text read from file.
 - Fixed FileNotFoundException crashing the Kotlin code, but not the Java code

Now, the two examples do exactly the same thing and handle errors the same way.