### PR TITLE
Fix syntax of second concurrency example

### DIFF
--- a/code/java/concurrency/02.java
+++ b/code/java/concurrency/02.java
@@ -1,13 +1,13 @@
 public <A> CompletableFuture<A> inTransaction(DatabaseFunction<A> fun) {
     return CompletableFuture
     .runAsync(() -> this.sendQuery("BEGIN"))
-    .thenApply(x -> fun.execute(this))
+    .thenApply(ignored -> fun.execute(this))
     .thenApply(s -> {
-    this.sendQuery("COMMIT");
-    return s;
+        this.sendQuery("COMMIT");
+        return s;
     })
-    .exceptionally(throwable -> {
-    this.sendQuery("ROLLBACK");
-    return null;
+        .exceptionally(throwable -> {
+        this.sendQuery("ROLLBACK");
+        return null;
     });
 }

--- a/code/java/concurrency/02.java
+++ b/code/java/concurrency/02.java
@@ -1,4 +1,4 @@
-public <A> CompletableFuture<A> inTransaction(DatabaseFunction<A> fun) {
+public <T> CompletableFuture<T> inTransaction(DatabaseFunction<T> fun) {
     return CompletableFuture
     .runAsync(() -> this.sendQuery("BEGIN"))
     .thenApply(ignored -> fun.execute(this))

--- a/code/kotlin/concurrency/02.kt
+++ b/code/kotlin/concurrency/02.kt
@@ -1,5 +1,5 @@
-suspend fun <A> inTransaction(
-    f: suspend (Connection) -> A): A {
+suspend fun <T> inTransaction(
+    f: suspend (Connection) -> T): T {
     try {
         this.sendQuery("BEGIN")
         val result = f(this)


### PR DESCRIPTION
Since I could not understand what the Java code was even meant to do, I took the Kotlin code and rewrote it in Java as I would have written it if I had never seen the Java side of it.